### PR TITLE
Fixed Type / Typo in constructor

### DIFF
--- a/Model/LoginAsCustomerRepository.php
+++ b/Model/LoginAsCustomerRepository.php
@@ -75,7 +75,7 @@ class LoginAsCustomerRepository implements LoginAsCustomerRepositoryInterface
      */
     public function __construct(
         ResourceLoginAsCustomer $resource,
-        loginAsCustomerFactory $loginAsCustomerFactory,
+        LoginAsCustomerFactory $loginAsCustomerFactory,
         LoginAsCustomerInterfaceFactory $dataLoginAsCustomerFactory,
         LoginAsCustomerCollectionFactory $loginAsCustomerCollectionFactory,
         LoginAsCustomerSearchResultsInterfaceFactory $searchResultsFactory,


### PR DESCRIPTION
Fixing issue when a user clicks on LoginAsCustomer in Backend that resulted in an error report, since the class could not be found.